### PR TITLE
Correção do GitHub Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 ## Oiii eu sou a Rafaella Ballerini, criadora de conteúdo de programação e tecnologia!
 
-Pessoal que veio atrás do **Github Stats:** a API provavelmente saiu do ar nesse período,
-mas você pode adicionar a sua própria, seguindo esse [tutorial](https://github.com/anuraghazra/github-readme-stats/blob/master/readme.md#deploy-on-your-own-vercel-instance)
+<div align="center">
+  <a href="https://github.com/rafaballerini">
+  <img height="180em" src="https://github-readme-stats.vercel.app/api?username=rafaballerini&theme=dracula&show_icons=true"/><br>
+  <img height="180em" src="https://github-readme-stats.vercel.app/api/top-langs/?username=rafaballerini&layout=compact&langs_count=6&theme=dracula"/>
+</div>
 
 <div style="display: inline_block"><br>
   <img align="center" alt="Rafa-Js" height="30" width="40" src="https://raw.githubusercontent.com/devicons/devicon/master/icons/javascript/javascript-plain.svg">


### PR DESCRIPTION
Correção do link quebrado do GitHub Stats, essa correção foi lançada pelo criador do recurso que pode ser vista [aqui](https://github.com/anuraghazra/github-readme-stats/issues/3243#issuecomment-1729450383)